### PR TITLE
Set up development environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo bundles three loosely-related pieces. Only the Discord bot is wired into `package.json`.
+
+### 1. M2 Support Bot (primary product — `src/`, `scripts/deploy-commands.js`)
+A `discord.js` v14 Discord bot (Node.js, CommonJS). Standard commands live in `package.json` (`npm start`, `npm run deploy`, `npm run lint` is a no-op stub — no linter/tests/build configured).
+
+Non-obvious caveats:
+- Running end-to-end requires a real `DISCORD_TOKEN` (Discord Gateway login). `npm start` and `npm run deploy` intentionally `process.exit(1)` early when `DISCORD_TOKEN` (and, for deploy, `DISCORD_APPLICATION_ID`) is missing — this is a guard, not a bug. There is no local Discord emulator, so a live token/bot is needed for a real end-to-end run. Provide it via a `.env` file (copy `.env.example`; `.env` is git-ignored) or environment variables.
+- The `/categorize` slash command and the free-text categorization template trigger require `OPENAI_API_KEY`; without it they respond gracefully with an "AI is not configured" message. All other commands (`/help`, `/checkin`, `/ground`, `/music`) and the grounding text triggers work with no OpenAI key.
+- Free-text triggers (e.g. "ground me", the categorization template) additionally require the "Message Content Intent" to be enabled in the Discord Developer Portal; slash commands work without it.
+- Command modules in `src/commands/*.js` are plain objects (`{ data, execute }`), so their logic can be exercised without Discord by calling `execute()` with a mock interaction — useful for verifying bot behavior without a token.
+
+### 2. Phoenix Crown 3D viewer (`public/phoenix-crown-3d.html`)
+A standalone Three.js/WebGL page with no build step. It loads Three.js from a CDN, so it needs internet access. Serve `public/` statically (e.g. `python3 -m http.server 8080` from `public/`, then open `http://localhost:8080/phoenix-crown-3d.html`) or open the file directly in a browser.
+
+### 3. Braille Plinko generator (`scripts/braille_plinko_core.py`)
+A standalone Python/Pillow library with no entrypoint and hardcoded font paths (`/home/claude/fonts/*.ttf`). Not part of the bot; requires `pip install Pillow` plus font files to render anything. Not needed to run or test the bot or the 3D viewer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the dev environment for this repo and documents non-obvious startup/run caveats for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the three bundled pieces (Discord bot, Phoenix Crown 3D viewer, Braille Plinko Python lib) and their run/test gotchas.
- Update script for future VMs: `npm install` (Node 18+; Node 22 verified).

No application code was modified.

## Verification
- `npm install` succeeds on Node 22.
- `npm run lint` runs (no-op stub, as configured).
- Discord bot command logic (`/help`, `/checkin`, `/ground`, `/music`, `/categorize`) exercised locally via mock interactions; `deploy-commands` builds command JSON for all 5 commands. Startup guards correctly exit when `DISCORD_TOKEN` is missing.
- Phoenix Crown 3D viewer served from `public/` and verified end-to-end in Chrome: view modes (Solid/Wireframe/Gems Only), camera presets (Front/Side/Top), and manual rotation all work.

[phoenix_crown_3d_viewer_demo_clean.mp4](https://cursor.com/agents/bc-46f3412b-5673-4e4f-a74e-ee553a0bd424/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoenix_crown_3d_viewer_demo_clean.mp4)

[Solid view](https://cursor.com/agents/bc-46f3412b-5673-4e4f-a74e-ee553a0bd424/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoenix_crown_solid.webp)
[Wireframe view](https://cursor.com/agents/bc-46f3412b-5673-4e4f-a74e-ee553a0bd424/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoenix_crown_wireframe.webp)
[Gems only view](https://cursor.com/agents/bc-46f3412b-5673-4e4f-a74e-ee553a0bd424/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoenix_crown_gems_only.webp)

Note: the trailing black frame with a rotating cube at the end of the video is the screen recorder's outro, not an app error (the same outro appears in a separate recording).

## Notes for reviewers
- Fully testing the Discord bot end-to-end requires a real `DISCORD_TOKEN` (Discord Gateway login); there is no local emulator. `/categorize` + the text template trigger additionally need `OPENAI_API_KEY`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46f3412b-5673-4e4f-a74e-ee553a0bd424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46f3412b-5673-4e4f-a74e-ee553a0bd424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

